### PR TITLE
create yaml version of json for cookiecutter replay

### DIFF
--- a/cookiecutter-easydata.yml
+++ b/cookiecutter-easydata.yml
@@ -1,0 +1,10 @@
+default_context:
+  author_name: John Healy, Amy Wooding
+  conda_path: ~/anaconda3/bin/conda
+  description: Reproducing EmbedAllTheThings by jc-healy and making it reproducible via easydata.
+  module_name: src
+  open_source_license: MIT
+  project_name: reproallthethings
+  python_version: latest
+  repo_name: reproallthethings
+  virtualenv: conda


### PR DESCRIPTION
We can hack replay into cookiecutter by creating a yaml version of our `cookiecutter-easydata.json` file and doing a:

```
cookiecutter --config-file reproallthethings/cookiecutter-easydata.yml cookiecutter-easydata
```

Still working on the git mojo to make this do what you want; i.e. merge back to the common root, replaying your changes on top.