### PR TITLE
Changes to Makefiles and configuration to enable environment creation on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,26 +49,24 @@ datasets: .make.datasets
 .PHONY: clean
 ## Delete all compiled Python files
 clean:
-	find . -type f -name "*.py[co]" -delete
-	find . -type d -name "__pycache__" -delete
-	rm -f .make.*
+	$(PYTHON_INTERPRETER) scripts/clean.py
 
 .PHONY: clean_interim
 clean_interim:
-	rm -rf data/interim/*
+	$(call rm,data/interim/*)
 
 .PHONY: clean_raw
 clean_raw:
-	rm -f data/raw/*
+	$(call rm,data/raw/*)
 
 .PHONY: clean_processed
 clean_processed:
-	rm -f data/processed/*
+	$(call rm,data/processed/*)
 
 .PHONY: clean_workflow
 clean_workflow:
-	rm -f catalog/datasources.json
-	rm -f catalog/transformer_list.json
+	$(call rm,catalog/datasources.json)
+	$(call rm,catalog/transformer_list.json)
 .PHONY: test
 
 ## Run all Unit Tests
@@ -84,46 +82,19 @@ test_with_coverage: update_environment
 		$(MODULE_NAME)
 
 .PHONY: lint
-# Lint using flake8
+## Lint using flake8
 lint:
 	flake8 $(MODULE_NAME)
 
 .phony: help_update_easydata
 help_update_easydata:
-	@echo "\nTo update easydata on an existing repo, verify that you have an 'easydata' branch"
-	@echo "\n>>>git rev-parse -q --verify easydata"
-	@echo "\nIf no output is given, do this:"
-	@echo "\n>>>git branch easydata `git rev-list --max-parents=0 HEAD`"
-	@echo "\nIf no output is given, do this:"
-	@echo "\nCheck-in all your changes, then merge the new easydata branch into yours"
-	@echo "\ngit branch easydata"
-	@echo "# replace easydata with https://github.com/hackalog/easydata if needed"
-	@echo "pushd .. && cookiecutter --config-file $(PROJECT_NAME)/.easydata.yml easydata -f --no-input && popd"
-	@echo "git add -p  # add all the changes"
-	@echo "git commit -m 'sync with easydata'"
-	@echo "git checkout main"
-	@echo "git merge easydata"
+	python scripts/help-update.py
 
 .PHONY: debug
 ## dump useful debugging information to $(DEBUG_FILE)
 debug:
-	@echo "\n\n======================"
-	@echo "\nPlease include the contents $(DEBUG_FILE) when submitting an issue or support request.\n"
-	@echo "======================\n\n"
-	@echo "##\n## Git status\n##\n" > $(DEBUG_FILE)
-	git status >> $(DEBUG_FILE)
-	@echo "\n##\n## git log\n##\n" >> $(DEBUG_FILE)
-	git log -8 --graph --oneline --decorate --all >> $(DEBUG_FILE)
-	@echo "\n##\n## Github remotes\n##\n" >> $(DEBUG_FILE)
-	git remote -v >> $(DEBUG_FILE)
-	@echo "\n##\n## github SSH credentials\n##\n" >> $(DEBUG_FILE)
-	ssh git@github.com 2>&1 | cat >> $(DEBUG_FILE)
-	@echo "\n##\n## Conda config\n##\n" >> $(DEBUG_FILE)
-	$(CONDA_EXE) config --get >> $(DEBUG_FILE)
-	@echo "\n##\n## Conda info\n##\n" >> $(DEBUG_FILE)
-	$(CONDA_EXE) info  >> $(DEBUG_FILE)
-	@echo "\n##\n## Conda list\n##\n" >> $(DEBUG_FILE)
-	$(CONDA_EXE) list >> $(DEBUG_FILE)
+	@python scripts/debug.py $(DEBUG_FILE)
+
 
 #################################################################################
 # PROJECT RULES                                                                 #
@@ -136,72 +107,6 @@ debug:
 #################################################################################
 
 .DEFAULT_GOAL := show-help
-
-# Inspired by <http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html>
-# sed script explained:
-# /^##/:
-# 	* save line in hold space
-# 	* purge line
-# 	* Loop:
-# 		* append newline + line to hold space
-# 		* go to next line
-# 		* if line starts with doc comment, strip comment character off and loop
-# 	* remove target prerequisites
-# 	* append hold space (+ newline) to line
-# 	* replace newline plus comments by `---`
-# 	* print line
-# Separate expressions are necessary because labels cannot be delimited by
-# semicolon; see <http://stackoverflow.com/a/11799865/1968>
 .PHONY: show-help
-
-
-print-%  : ; @echo $* = $($*)
-
-HELP_VARS := PROJECT_NAME DEBUG_FILE
-
-help-prefix:
-	@echo "To get started:"
-	@echo "  >>> $$(tput bold)make create_environment$$(tput sgr0)"
-	@echo "  >>> $$(tput bold)conda activate $(PROJECT_NAME)$$(tput sgr0)"
-	@echo ""
-	@echo "$$(tput bold)Project Variables:$$(tput sgr0)"
-	@echo ""
-
-show-help: help-prefix $(addprefix print-, $(HELP_VARS))
-	@echo
-	@echo "$$(tput bold)Available rules:$$(tput sgr0)"
-	@sed -n -e "/^## / { \
-		h; \
-		s/.*//; \
-		:doc" \
-		-e "H; \
-		n; \
-		s/^## //; \
-		t doc" \
-		-e "s/:.*//; \
-		G; \
-		s/\\n## /---/; \
-		s/\\n/ /g; \
-		p; \
-	}" ${MAKEFILE_LIST} \
-	| LC_ALL='C' sort --ignore-case \
-	| awk -F '---' \
-		-v ncol=$$(tput cols) \
-		-v indent=19 \
-		-v col_on="$$(tput setaf 6)" \
-		-v col_off="$$(tput sgr0)" \
-	'{ \
-		printf "%s%*s%s ", col_on, -indent, $$1, col_off; \
-		n = split($$2, words, " "); \
-		line_length = ncol - indent; \
-		for (i = 1; i <= n; i++) { \
-			line_length -= length(words[i]) + 1; \
-			if (line_length <= 0) { \
-				line_length = ncol - indent - length(words[i]) - 1; \
-				printf "\n%*s ", -indent, " "; \
-			} \
-			printf "%s ", words[i]; \
-		} \
-		printf "\n"; \
-	}' \
-	| more $(shell test $(shell uname) = Darwin && echo '--no-init --raw-control-chars')
+show-help:
+	@python scripts/help.py $(PROJECT_NAME) $(DEBUG_FILE)

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -8,7 +8,6 @@ $(EASYDATA_LOCKFILE): environment.yml
 ifeq (conda, $(VIRTUALENV))
 	$(CONDA_EXE) env update -n $(PROJECT_NAME) -f $<
 	$(CONDA_EXE) env export -n $(PROJECT_NAME) -f $@
-	# pip install -e .  # uncomment for conda <= 4.3
 else
 	$(error Unsupported Environment `$(VIRTUALENV)`. Use conda)
 endif
@@ -17,13 +16,10 @@ endif
 ## Set up virtual (conda) environment for this project
 create_environment: $(EASYDATA_LOCKFILE)
 ifeq (conda,$(VIRTUALENV))
-	@rm -f $(EASYDATA_LOCKFILE)
-	@echo
-	@echo "New conda env created. Activate with:"
-	@echo ">>> conda activate $(PROJECT_NAME)"
-	@echo ">>> make update_environment"
+	@$(call rm,$(EASYDATA_LOCKFILE))
+	@python -c "print('\nNew conda env created. Activate with:\n>>> conda activate $(PROJECT_NAME)\n>>> make update_environment')"
 ifneq ("X$(wildcard .post-create-environment.txt)","X")
-	@cat .post-create-environment.txt
+	@$(call type,.post-create-environment.txt)
 endif
 else
 	$(error Unsupported Environment `$(VIRTUALENV)`. Use conda)
@@ -35,9 +31,9 @@ delete_environment:
 ifeq (conda,$(VIRTUALENV))
 	@echo "Deleting conda environment."
 	$(CONDA_EXE) env remove -n $(PROJECT_NAME)
-	rm -f $(EASYDATA_LOCKFILE)
+	$(call rm,$(EASYDATA_LOCKFILE))
 ifneq ("X$(wildcard .post-delete-environment.txt)","X")
-	@cat .post-delete-environment.txt
+	@$(call type,.post-delete-environment.txt)
 endif
 else
 	$(error Unsupported Environment `$(VIRTUALENV)`. Use conda)
@@ -47,7 +43,7 @@ endif
 ## Install or update Python Dependencies in the virtual (conda) environment
 update_environment: environment_enabled $(EASYDATA_LOCKFILE)
 ifneq ("X$(wildcard .post-update-environment.txt)","X")
-	@cat .post-update-environment.txt
+	@$(call type,.post-update_environment.txt)
 endif
 
 .PHONY: environment_enabled

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,10 +1,14 @@
 CONDA_EXE ?= ~/miniconda3/bin/conda
+PYTHON_INTERPRETER := $(if $(findstring Python 3,$(shell python --version)),python,python3)
 DEBUG_FILE := debug.txt
 MODULE_NAME := src
 TESTS_NO_CI = $(MODULE_NAME)/tests/no_ci
-PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+PROJECT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 PROJECT_NAME := reproallthethings
-PYTHON_INTERPRETER := python3
 ARCH := $(shell $(PYTHON_INTERPRETER) -c "import platform; print(platform.platform())")
 VIRTUALENV := conda
 EASYDATA_LOCKFILE := environment.$(ARCH).lock.yml
+PLATFORM = $(shell $(PYTHON_INTERPRETER) -c "import sys; print(sys.platform)")
+
+rm = python scripts/rm.py "$(1)"
+type = python -c "import pathlib; print(pathlib.Path('$(1)').read_text())"

--- a/environment.yml
+++ b/environment.yml
@@ -40,3 +40,4 @@ dependencies:
   - python=3.7
   - conda-forge::hdbscan
   - conda-forge::umap-learn
+  - conda-forge::rich

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
     - nbdime
     - datashader
     - holoviews
-    - umap-learn>=0.4.0rc1
     - enstop
     - coveralls
     - git+https://github.com/TutteInstitute/vectorizers.git
@@ -39,3 +38,5 @@ dependencies:
   - numba
   - fsspec
   - python=3.7
+  - conda-forge::hdbscan
+  - conda-forge::umap-learn

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+import shutil
+
+
+for path_, dirs, files in os.walk("."):
+    path = Path(path_)
+    try:
+        i_pycache = dirs.index("__pycache__")
+        shutil.rmtree(str(path / "__pycache__"))
+        del dirs[i_pycache]
+    except ValueError:
+        pass
+        
+    for file_ in files:
+        file = path / file_
+        ext = file.suffix
+        if any(ext.endswith(x) for x in ["pyo", "pyc"]):
+            file.unlink()
+            
+for p in Path(".").glob(".make.*"):
+    p.unlink()

--- a/scripts/debug.py
+++ b/scripts/debug.py
@@ -1,0 +1,41 @@
+import os
+from subprocess import run, STDOUT
+import sys
+
+
+assert len(sys.argv) >= 2
+path_debug = sys.argv[1]
+
+with open(path_debug, "wb") as file_debug:
+    def shell_out(*cmd):
+        return run(list(cmd), stdout=file_debug, stderr=STDOUT, input=b"yes\n")
+
+    def heading(h):
+        file_debug.write(bytes(f"\n##\n## {h}\n##\n", encoding="utf-8"))
+        file_debug.flush()
+
+    heading("Git status")
+    shell_out("git", "status")
+
+    heading("git log")
+    shell_out("git", "log", "-8", "--graph", "--oneline", "--decorate", "--all")
+    
+    heading("Git remotes")
+    shell_out("git", "remote", "-v")
+    
+    heading("GitHub SSH credentials")
+    shell_out("ssh", "git@github.com")
+    
+    heading("Conda config")
+    shell_out(os.environ["CONDA_EXE"], "config", "--get")
+    
+    heading("Conda info")
+    shell_out(os.environ["CONDA_EXE"], "info")
+    
+    heading("Conda list")
+    shell_out(os.environ["CONDA_EXE"], "list")
+
+msg = f"Please include the contents of {path_debug} when submitting an issue or support request."
+print("=" * len(msg))
+print(msg)
+print("=" * len(msg))

--- a/scripts/help-update.py
+++ b/scripts/help-update.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+here = Path.cwd().name
+print(f"""\
+To update easydata on an existing repo, verify that you have an 'easydata' branch
+
+>>> git rev-parse -q --verify easydata
+
+If no output is given, do this:
+
+>>> git rev-list --max-parents=0 HEAD
+
+and copy-paste the output hash in this command:
+
+>>> git branch easydata #PASTE HASH HERE#
+
+Once you have the easydata branch, let's commit ("check in") all your changes,
+then merge the new easydata branch into yours:
+
+cd ..
+cookiecutter --config-file {here}/.easydata.yml easydata -f --no-input
+cd {here}
+git add -p  # add all the changes
+git commit -m "sync with easydata"
+git checkout main
+git merge easydata
+""")

--- a/scripts/help.py
+++ b/scripts/help.py
@@ -1,0 +1,65 @@
+import sys
+
+try:
+    from rich import print
+    B = "[b]"
+    nB = "[/b]"
+    CYAN = "[cyan]"
+    nCYAN = "[/cyan]"
+except ImportError:
+    if sys.platform.lower() == "win32":
+        B = ""
+        nB = ""
+        CYAN = ""
+        nCYAN = ""
+    else:
+        HEY = "\x1e["
+        B = f"{HEY}1n"
+        nB = f"{HEY}0n"
+        CYAN = f"{HEY}36n"
+        nCYAN = f"{HEY}0n"
+    
+
+def deprint(s):
+    print(s, end="")
+    
+    
+assert len(sys.argv) == 3
+project_name, debug_file = sys.argv[1:3]
+
+deprint(f"""\
+To get started:
+  >>> {B}make create_environment{nB}
+  >>> {B}conda activate {project_name}{nB}
+
+{B}Project variables:{nB}
+
+""")
+print(f"PROJECT_NAME = {sys.argv[1]}")
+print(f"DEBUG_FILE   = {sys.argv[2]}")
+
+deprint(f"""\
+
+{B}Available rules:{nB}
+
+""")
+rules = []
+for path in ["Makefile", "Makefile.include", "Makefile.envs"]:
+    with open(path, "r", encoding="utf-8") as makefile:
+        while True:
+            try:
+                line = next(makefile)
+                lines_doc = []
+                while line.startswith("## "):
+                    lines_doc.append(line[2:])
+                    line = next(makefile)
+                if lines_doc:
+                    # We have collected some documentation. Current line now contains the target name.
+                    target, *_ = line.split(":")
+                    rules.append((target, " ".join(ld.strip() for ld in lines_doc)))
+            except StopIteration:
+                break
+
+width_target = max([len(target) for target, _ in rules])
+for target, doc in sorted(rules, key=lambda p: p[0]):
+    print(f"{CYAN}{target:{width_target}}{nCYAN}  {doc}")

--- a/scripts/rm.py
+++ b/scripts/rm.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import shutil
+import sys
+
+
+for pattern in sys.argv[1:]:
+    for path in Path(".").glob(pattern):
+        if path.is_dir():
+            shutil.rmtree(str(path))
+        else:
+            path.unlink()


### PR DESCRIPTION
The key is to replace UNIX tool invocations with small Python programs. These port across environments more easily.

Furthermore, banking on the existence of `python3` on Windows is not possible. Anaconda/Miniconda on this platform does not deploy `python` as a Python 2 invocation. Contrary to @hackalog 's rant, PEP0394 only matters on UNIX-ish environments, which Windows is not. Fortunately, whatever platform tweaking is necessary is easily enabled from the Makefile.

Out of these modifications, only 4 tools are necessary for EasyData to work across all 3 major general computing platforms:

1. Git
2. Conda
    1. Python
    2. GNU Make

 Small conventions around rule implementation in the Makefiles leverage the similitudes between Bash and command.com.